### PR TITLE
Dispose the world object only after _hook.onAfterScenario is called

### DIFF
--- a/lib/src/feature_file_runner.dart
+++ b/lib/src/feature_file_runner.dart
@@ -255,8 +255,6 @@ class FeatureFileRunner {
           );
         }
       }
-
-      world?.dispose();
     } catch (e, st) {
       await _reporter.onException(e, st);
 
@@ -274,6 +272,13 @@ class FeatureFileRunner {
         scenario.name,
         tags,
       );
+    }
+
+    try {
+      world?.dispose();
+    } catch (e, st) {
+      await _reporter.onException(e, st);
+      rethrow;
     }
 
     return scenarioPassed;


### PR DESCRIPTION
Hello @jonsamwell,
While implementing the performance framework with the help of hooks, I found that the world object is disposed before the _hook.onAfterScenario is called.
This results in flutter_driver not being available anymore and getting error when calling the driver.stopTracingAndDownloadTimeline.

I validated that the proposed change is unblocking the issue, but I am not sure if it introduces side effects for other scenarios.

Thank you