### PR TITLE
add exitAfterTestFailed option

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -55,6 +55,9 @@ class TestConfiguration {
   /// the program will exit after all the tests have run
   bool exitAfterTestRun = true;
 
+  /// the program will exit after any test failed
+  bool exitAfterTestFailed = true;
+
   /// used to allow for custom configuration to ensure framework specific configuration is in place
   void prepare() {}
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -56,7 +56,7 @@ class TestConfiguration {
   bool exitAfterTestRun = true;
 
   /// the program will exit after any test failed
-  bool exitAfterTestFailed = true;
+  bool exitAfterTestFailed = false;
 
   /// used to allow for custom configuration to ensure framework specific configuration is in place
   void prepare() {}

--- a/lib/src/test_runner.dart
+++ b/lib/src/test_runner.dart
@@ -84,6 +84,7 @@ class GherkinRunner {
             _hook,
           );
           allFeaturesPassed &= await runner.run(featureFile);
+          if (config.exitAfterTestFailed && !allFeaturesPassed) break;
         }
       } finally {
         await _reporter.onTestRunFinished();


### PR DESCRIPTION
Context:
We are using the gherkin runner for the integration test on both mobile and web. Some scenarios take a long time to complete.
But when the test failed instead of the runner stops, it still is running cause consuming more time and resources so we need this feature.

If you have any suggestions, please comment. @jonsamwell 

