### PR TITLE
Add exit after test fail option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Available as a Flutter specific package https://pub.dartlang.org/packages/flutte
     - [reporters](#reporters)
     - [createWorld](#createworld)
     - [exitAfterTestRun](#exitaftertestrun)
+    - [exitAfterTestFailed](#exitAfterTestFailed)
 * [Features Files](#features-files)
   + [Steps Definitions](#steps-definitions)
     - [Given](#given)
@@ -223,7 +224,8 @@ Future<void> main() {
       WhenTheStoredNumbersAreAdded(),
       ThenExpectNumericResult()
     ]
-    ..exitAfterTestRun = true;
+    ..exitAfterTestRun = true
+    ..exitAfterTestFailed = false;
 
   return GherkinRunner().execute(config);
 ```
@@ -354,6 +356,11 @@ Future<void> main() {
 
 Defaults to `true`
 True to exit the program after all tests have run.  You may want to set this to false during debugging.
+
+#### exitAfterTestFailed
+
+Defaults to `false`
+True to exit the program when a test have failed.  You may want to set this to true during debugging.
 
 ## Features Files
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -55,6 +55,9 @@ class TestConfiguration {
   /// the program will exit after all the tests have run
   bool exitAfterTestRun = true;
 
+  /// the program will exit after any test failed
+  bool exitAfterTestFailed = false;
+
   /// used to allow for custom configuration to ensure framework specific configuration is in place
   void prepare() {}
 
@@ -77,6 +80,7 @@ class TestConfiguration {
         JsonReporter(path: './report.json')
       ]
       ..stepDefinitions = steps
-      ..exitAfterTestRun = true;
+      ..exitAfterTestRun = true
+      ..exitAfterTestFailed = false;
   }
 }

--- a/lib/src/feature_file_runner.dart
+++ b/lib/src/feature_file_runner.dart
@@ -39,6 +39,7 @@ class FeatureFileRunner {
     var haveAllFeaturesPassed = true;
     for (var feature in featureFile.features) {
       haveAllFeaturesPassed &= await _runFeature(feature);
+      if (_config.exitAfterTestFailed && !haveAllFeaturesPassed) break;
     }
 
     return haveAllFeaturesPassed;
@@ -72,6 +73,7 @@ class FeatureFileRunner {
         if (_canRunScenario(_config.tagExpression, scenario)) {
           haveAllScenariosPassed &=
               await _runScenarioInZone(scenario, feature.background);
+          if (_config.exitAfterTestFailed && !haveAllScenariosPassed) break;
         } else {
           await _log(
             "Ignoring scenario '${scenario.name}' as tag expression '${_config.tagExpression}' not satisfied",

--- a/lib/src/feature_file_runner.dart
+++ b/lib/src/feature_file_runner.dart
@@ -39,7 +39,9 @@ class FeatureFileRunner {
     var haveAllFeaturesPassed = true;
     for (var feature in featureFile.features) {
       haveAllFeaturesPassed &= await _runFeature(feature);
-      if (_config.exitAfterTestFailed && !haveAllFeaturesPassed) break;
+      if (_config.exitAfterTestFailed && !haveAllFeaturesPassed) {
+        break;
+      }
     }
 
     return haveAllFeaturesPassed;
@@ -73,7 +75,9 @@ class FeatureFileRunner {
         if (_canRunScenario(_config.tagExpression, scenario)) {
           haveAllScenariosPassed &=
               await _runScenarioInZone(scenario, feature.background);
-          if (_config.exitAfterTestFailed && !haveAllScenariosPassed) break;
+          if (_config.exitAfterTestFailed && !haveAllScenariosPassed) {
+            break;
+          }
         } else {
           await _log(
             "Ignoring scenario '${scenario.name}' as tag expression '${_config.tagExpression}' not satisfied",

--- a/lib/src/test_runner.dart
+++ b/lib/src/test_runner.dart
@@ -84,6 +84,7 @@ class GherkinRunner {
             _hook,
           );
           allFeaturesPassed &= await runner.run(featureFile);
+          if (config.exitAfterTestFailed && !allFeaturesPassed) break;
         }
       } finally {
         await _reporter.onTestRunFinished();

--- a/lib/src/test_runner.dart
+++ b/lib/src/test_runner.dart
@@ -84,7 +84,9 @@ class GherkinRunner {
             _hook,
           );
           allFeaturesPassed &= await runner.run(featureFile);
-          if (config.exitAfterTestFailed && !allFeaturesPassed) break;
+          if (config.exitAfterTestFailed && !allFeaturesPassed) {
+            break;
+          }
         }
       } finally {
         await _reporter.onTestRunFinished();

--- a/test/feature_file_runner_test.dart
+++ b/test/feature_file_runner_test.dart
@@ -105,6 +105,73 @@ void main() {
       expect(stepDefinitonTwo.runCount, 0);
     });
 
+    test('feature are skipped if previous feature failed', () async {
+      final stepTextOne = 'Given I do a';
+      final stepTextTwo = 'Given I do b';
+      final stepDefiniton = MockStepDefinition((_) => throw Exception());
+      final stepDefinitonTwo = MockStepDefinition();
+      final executableStep = ExecutableStep(
+          MockGherkinExpression((s) => s == stepTextOne), stepDefiniton);
+      final executableStepTwo = ExecutableStep(
+          MockGherkinExpression((s) => s == stepTextTwo), stepDefinitonTwo);
+      final runner = FeatureFileRunner(
+          TestConfiguration()..exitAfterTestFailed = true,
+          MockTagExpressionEvaluator(),
+          [executableStep, executableStepTwo],
+          ReporterMock(),
+          HookMock());
+      final stepOne =
+          StepRunnable('Step 1', RunnableDebugInformation('', 0, stepTextOne));
+      final stepTwo =
+          StepRunnable('Step 2', RunnableDebugInformation('', 0, stepTextTwo));
+      final scenarioOne = ScenarioRunnable('Scenario: 1', emptyDebuggable)
+        ..steps.add(stepOne);
+      final scenarioTwo = ScenarioRunnable('Scenario: 2', emptyDebuggable)
+        ..steps.add(stepTwo);
+      final featureOne = FeatureRunnable('1', emptyDebuggable)
+        ..scenarios.add(scenarioOne);
+      final featureTwo = FeatureRunnable('2', emptyDebuggable)
+        ..scenarios.add(scenarioTwo);
+      final featureFile = FeatureFile(emptyDebuggable)
+        ..features.addAll([featureOne, featureTwo]);
+      await runner.run(featureFile);
+      expect(stepDefiniton.hasRun, true);
+      expect(stepDefiniton.runCount, 1);
+      expect(stepDefinitonTwo.runCount, 0);
+    });
+
+    test('scenario are skipped if previous scenario failed', () async {
+      final stepTextOne = 'Given I do a';
+      final stepTextTwo = 'Given I do b';
+      final stepDefiniton = MockStepDefinition((_) => throw Exception());
+      final stepDefinitonTwo = MockStepDefinition();
+      final executableStep = ExecutableStep(
+          MockGherkinExpression((s) => s == stepTextOne), stepDefiniton);
+      final executableStepTwo = ExecutableStep(
+          MockGherkinExpression((s) => s == stepTextTwo), stepDefinitonTwo);
+      final runner = FeatureFileRunner(
+          TestConfiguration()..exitAfterTestFailed = true,
+          MockTagExpressionEvaluator(),
+          [executableStep, executableStepTwo],
+          ReporterMock(),
+          HookMock());
+      final stepOne =
+          StepRunnable('Step 1', RunnableDebugInformation('', 0, stepTextOne));
+      final stepTwo =
+          StepRunnable('Step 2', RunnableDebugInformation('', 0, stepTextTwo));
+      final scenarioOne = ScenarioRunnable('Scenario: 1', emptyDebuggable)
+        ..steps.add(stepOne);
+      final scenarioTwo = ScenarioRunnable('Scenario: 2', emptyDebuggable)
+        ..steps.add(stepTwo);
+      final feature = FeatureRunnable('1', emptyDebuggable)
+        ..scenarios.addAll([scenarioOne, scenarioTwo]);
+      final featureFile = FeatureFile(emptyDebuggable)..features.add(feature);
+      await runner.run(featureFile);
+      expect(stepDefiniton.hasRun, true);
+      expect(stepDefiniton.runCount, 1);
+      expect(stepDefinitonTwo.runCount, 0);
+    });
+
     test('Unchecked errors are handled gracefully', () async {
       final stepTextOne = 'Given I do a';
       final stepTextTwo = 'Given I do b';


### PR DESCRIPTION
This is based on my co-worker PR: https://github.com/jonsamwell/dart_gherkin/pull/24. Very thanks to him for guiding me.

Context:
We are using the gherkin runner for the integration test on both mobile and web. Some scenarios take a long time to complete.
But when the test failed instead of the runner stops, it still is running. Because it consumes more time and resources so we need this feature.

Solution:
- Add `exitAfterTestFailed` attribute to Test Configuration

Pros: 
- Tests can stop immediately when failed and we will know the root problem. 

My limitation:
- I can't cover test the `test_runner.dart` file. 

If you have any suggestions, please let me know. @jonsamwell

