### PR TITLE
preserve intended indentation in multiline strings

### DIFF
--- a/lib/src/gherkin/parser.dart
+++ b/lib/src/gherkin/parser.dart
@@ -1,5 +1,6 @@
 import 'package:gherkin/src/gherkin/languages/language_service.dart';
 import 'package:gherkin/src/gherkin/runnables/dialect_block.dart';
+import 'package:gherkin/src/gherkin/runnables/multi_line_string.dart';
 
 import './exceptions/syntax_error.dart';
 import './runnables/debug_information.dart';
@@ -95,8 +96,10 @@ class GherkinParser {
           }
         }
 
+        final useUntrimmedLines = matcher is MultilineStringSyntax ||
+            parentBlock is MultilineStringRunnable;
         final runnable = matcher.toRunnable(
-          line,
+          useUntrimmedLines ? lines.elementAt(i) : line,
           parentBlock.debug.copyWith(i, line),
           dialect,
         );

--- a/lib/src/gherkin/runnables/multi_line_string.dart
+++ b/lib/src/gherkin/runnables/multi_line_string.dart
@@ -7,12 +7,17 @@ import './runnable_block.dart';
 import './text_line.dart';
 
 class MultilineStringRunnable extends RunnableBlock {
+  int leadingWhitespace;
+
   List<String> lines = <String>[];
 
   @override
   String get name => 'Multiline String';
 
-  MultilineStringRunnable(RunnableDebugInformation debug) : super(debug);
+  MultilineStringRunnable(
+    RunnableDebugInformation debug, {
+    this.leadingWhitespace,
+  }) : super(debug);
 
   @override
   void addChild(Runnable child) {
@@ -20,7 +25,9 @@ class MultilineStringRunnable extends RunnableBlock {
         "Unknown runnable child given to Multiline string '${child.runtimeType}'");
     switch (child.runtimeType) {
       case TextLineRunnable:
-        lines.add((child as TextLineRunnable).text);
+        final text = (child as TextLineRunnable).originalText ??
+            (child as TextLineRunnable).text;
+        lines.add(stripLeadingIndentation(text));
         break;
       case EmptyLineRunnable:
         lines.add('');
@@ -31,5 +38,15 @@ class MultilineStringRunnable extends RunnableBlock {
       default:
         throw exception;
     }
+  }
+
+  /// Trim but retain intentional indentation
+  String stripLeadingIndentation(String lineText) {
+    if (lines.isEmpty && leadingWhitespace == null) {
+      leadingWhitespace =
+          RegExp(r'^(\s*)').firstMatch(lineText)?.group(1)?.length ?? 0;
+    }
+
+    return lineText.substring(leadingWhitespace ?? 0);
   }
 }

--- a/lib/src/gherkin/runnables/text_line.dart
+++ b/lib/src/gherkin/runnables/text_line.dart
@@ -4,6 +4,10 @@ import './runnable.dart';
 class TextLineRunnable extends Runnable {
   String text;
 
+  /// While [text] can be `trim()`'d, original whitespace will be preserved
+  /// in `originalText`.
+  String originalText;
+
   @override
   String get name => 'Language';
 

--- a/lib/src/gherkin/syntax/multiline_string_syntax.dart
+++ b/lib/src/gherkin/syntax/multiline_string_syntax.dart
@@ -41,8 +41,11 @@ class MultilineStringSyntax extends RegExMatchedGherkinSyntax {
     String line,
     RunnableDebugInformation debug,
     GherkinDialect dialect,
-  ) =>
-      MultilineStringRunnable(debug);
+  ) {
+    final leadingWhitespace =
+        RegExp(r'^(\s*)').firstMatch(line)?.group(1)?.length ?? 0;
+    return MultilineStringRunnable(debug, leadingWhitespace: leadingWhitespace);
+  }
 
   @override
   EndBlockHandling endBlockHandling(SyntaxMatcher syntax) =>

--- a/lib/src/gherkin/syntax/text_line_syntax.dart
+++ b/lib/src/gherkin/syntax/text_line_syntax.dart
@@ -22,6 +22,7 @@ class TextLineSyntax extends RegExMatchedGherkinSyntax {
     GherkinDialect dialect,
   ) {
     final runnable = TextLineRunnable(debug);
+    runnable.originalText = line;
     runnable.text = line.trim();
     return runnable;
   }

--- a/test/gherkin/runnables/multi_line_string_test.dart
+++ b/test/gherkin/runnables/multi_line_string_test.dart
@@ -13,11 +13,23 @@ void main() {
     });
     test('can add TextLineRunnable', () {
       final runnable = MultilineStringRunnable(debugInfo);
-      runnable.addChild(TextLineRunnable(debugInfo)..text = '1');
-      runnable.addChild(TextLineRunnable(debugInfo)..text = '2');
-      runnable.addChild(TextLineRunnable(debugInfo)..text = '3');
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '1');
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '2');
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '3');
       expect(runnable.lines.length, 3);
       expect(runnable.lines, ['1', '2', '3']);
+    });
+  });
+
+  group('stripLeadingIndentation', () {
+    test('preserve original indentation without aggressively trimming', () {
+      final runnable = MultilineStringRunnable(debugInfo);
+
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '   1');
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '    2');
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '    3');
+      expect(runnable.lines.length, 3);
+      expect(runnable.lines, ['1', ' 2', ' 3']);
     });
   });
 }

--- a/test/gherkin/runnables/multi_line_string_test.dart
+++ b/test/gherkin/runnables/multi_line_string_test.dart
@@ -22,7 +22,7 @@ void main() {
   });
 
   group('stripLeadingIndentation', () {
-    test('preserve original indentation without aggressively trimming', () {
+    test('preserve original indentation from the first line', () {
       final runnable = MultilineStringRunnable(debugInfo);
 
       runnable.addChild(TextLineRunnable(debugInfo)..originalText = '   1');
@@ -30,6 +30,16 @@ void main() {
       runnable.addChild(TextLineRunnable(debugInfo)..originalText = '    3');
       expect(runnable.lines.length, 3);
       expect(runnable.lines, ['1', ' 2', ' 3']);
+    });
+
+    test('preserve original indentation from a specified position', () {
+      final runnable = MultilineStringRunnable(debugInfo, leadingWhitespace: 4);
+
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '       1');
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '      2');
+      runnable.addChild(TextLineRunnable(debugInfo)..originalText = '     3');
+      expect(runnable.lines.length, 3);
+      expect(runnable.lines, ['   1', '  2', ' 3']);
     });
   });
 }


### PR DESCRIPTION
Addresses #23. Indentation is preserved at the first code fence. If this is undetermined, indentation to remove is determined by the first line's leading whitespace. 