### PR TITLE
allow escaped pipes in tables

### DIFF
--- a/lib/src/gherkin/runnables/table.dart
+++ b/lib/src/gherkin/runnables/table.dart
@@ -42,8 +42,12 @@ class TableRunnable extends RunnableBlock {
   }
 
   TableRow _toRow(String raw, int rowIndex, [isHeaderRow = false]) {
-    final columns =
-        raw.trim().split(RegExp(r'\|')).map((c) => c.trim()).skip(1).toList();
+    final columns = raw
+        .trim()
+        .split(RegExp(r'(?<!\\)\|'))
+        .map((c) => c.trim().replaceAll(r'\|', '|'))
+        .skip(1)
+        .toList();
 
     return TableRow(
       columns

--- a/test/gherkin/runnables/table_test.dart
+++ b/test/gherkin/runnables/table_test.dart
@@ -163,5 +163,19 @@ void main() {
         'header three': 'nine',
       });
     });
+
+    test('pipes can be escaped', () async {
+      final runnable = TableRunnable(debugInfo);
+      runnable.addChild(TableRunnable(debugInfo)
+        ..rows.add(
+            r'| one \| with escaped pipe | two | three with \| escaped pipe |'));
+      final maps = runnable.toTable().asMap();
+      expect(maps.length, 1);
+      expect(maps.elementAt(0), {
+        '0': 'one | with escaped pipe',
+        '1': 'two',
+        '2': 'three with | escaped pipe'
+      });
+    });
   });
 }


### PR DESCRIPTION
This permits defining pipes within tables. Other Gherkin runners support this syntax:

* [Ruby](https://github.com/cucumber/cucumber-ruby/issues/1006)
* [Behave](https://github.com/behave/behave/issues/302)
* [CucumberJS](https://github.com/cucumber/cucumber-js/issues/417) (sorry this is super lazy; the issue is resolved somewhere in the [Gherkin core](https://github.com/cucumber/gherkin-javascript))