### PR TITLE
support sorted feature files

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -12,7 +12,7 @@ typedef CreateAttachmentManager = Future<AttachmentManager> Function(
   TestConfiguration config,
 );
 
-enum ExecutionOrder { sequential, random }
+enum ExecutionOrder { sequential, random, sorted }
 
 class TestConfiguration {
   /// The glob path(s) to all the features

--- a/lib/src/test_runner.dart
+++ b/lib/src/test_runner.dart
@@ -69,7 +69,15 @@ class GherkinRunner {
           MessageLevel.info,
         );
         featureFiles = featureFiles.toList()..shuffle();
+      } else if (config.order == ExecutionOrder.sorted) {
+        await _reporter.message(
+          'Executing features in sorted order',
+          MessageLevel.info,
+        );
+        featureFiles
+            .sort((FeatureFile a, FeatureFile b) => a.name.compareTo(b.name));
       }
+
 
       await _hook.onBeforeRun(config);
 


### PR DESCRIPTION
I confirmed if there is only one FeatureFile, the `sort` method does not error.  This was tested with my setup.