### PR TITLE
remove test dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [2.0.0] - 15/02/2021
+## [2.0.1] - 15/04/2021
+
+* BREAKING CHANGE: `TestFailure` is no longer thrown when an `expect` fails. Instead, use `GherkinTestFailure` when catching errors (i.e. replace `on TestFailure catch` with `on GherkinTestFailure catch`) (#37).
+
+## [2.0.0] - 15/04/2021
 
 NOTE: Massive changes here due to the migration to null-safety and laying the foundation for code generation to enable testing Flutter apps using the `integration_test` package.
 

--- a/lib/src/expect/expect_mimic.dart
+++ b/lib/src/expect/expect_mimic.dart
@@ -47,7 +47,7 @@ class ExpectMimic {
     String? reason,
   }) {
     final matchState = {};
-    matcher = _wrapMatcher(matcher);
+    matcher = wrapMatcher(matcher);
     final result = matcher.matches(actualValue, matchState);
     final formatter = (actual, matcher, reason, matchState, verbose) {
       final mismatchDescription = StringDescription();
@@ -61,22 +61,6 @@ class ExpectMimic {
     if (!result) {
       throw GherkinTestFailure(formatter(
           actualValue, matcher as Matcher, reason, matchState, false));
-    }
-  }
-
-  Matcher _wrapMatcher(x) {
-    if (x is Matcher) {
-      return x;
-    } else if (x is bool Function(Object?)) {
-      // x is already a predicate that can handle anything
-      return predicate(x);
-    } else if (x is bool Function(Never)) {
-      // x is a unary predicate, but expects a specific type
-      // so wrap it.
-      // ignore: unnecessary_lambdas
-      return predicate((a) => (x as dynamic)(a));
-    } else {
-      return equals(x);
     }
   }
 }

--- a/lib/src/gherkin/steps/step_definition.dart
+++ b/lib/src/gherkin/steps/step_definition.dart
@@ -1,10 +1,11 @@
+import 'package:gherkin/src/expect/expect_mimic.dart';
+
 import '../../utils/perf.dart';
 import './step_run_result.dart';
 import '../../reporters/reporter.dart';
 import './step_configuration.dart';
 import './world.dart';
 import '../exceptions/parameter_count_mismatch_error.dart';
-import 'package:test/test.dart';
 import 'dart:async';
 
 abstract class StepDefinitionGeneric<TWorld extends World> {
@@ -46,7 +47,7 @@ abstract class StepDefinitionGeneric<TWorld extends World> {
         },
         (ms) => elapsedMilliseconds = ms,
       );
-    } on TestFailure catch (tf) {
+    } on GherkinTestFailure catch (tf) {
       return StepResult(
         elapsedMilliseconds,
         StepExecutionResult.fail,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,7 +268,7 @@ packages:
     source: hosted
     version: "1.2.0"
   test:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ description: A Gherkin parsers and runner for Dart which is very similar to Cucu
 homepage: https://github.com/jonsamwell/dart_gherkin
 
 dependencies:
-  test: ^1.16.8
   path: ^1.8.0
   matcher: ^0.12.10
   collection: ^1.15.0
 
 dev_dependencies:
+  test: ^1.16.8
   pedantic: ^1.11.0
   glob: ^2.0.1
 


### PR DESCRIPTION
This removes the `test` package as a dependency from `dart_gherkin`, loosening the restriction in `flutter_gherkin` and its dependence on whatever strict package tree `test_driver` defines. 

The biggest difference is not using `test`'s `fail` and instead introducing a `GherkinTestFailure`. This will be a breaking change in tests that use `TestFailure`, but I believe the tradeoff is worth it and can be part of the other breaking changes in the null safety release. 