### PR TITLE
Readme wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Future<void> main() {
       ThenExpectNumericResult()
   ];
   final config = TestConfiguration.DEFAULT(steps)
-    ..featureFileReader = IoFeatureFileReader(latin1);
+    ..featureFileReader = IoFeatureFileReader(encoding: latin1);
 
   return GherkinRunner().execute(config);
 }

--- a/README.md
+++ b/README.md
@@ -343,15 +343,15 @@ Future<void> main() {
 }
 ```
 
-#### featureFileIndexer
+#### featureFileMatcher
 
-`FeatureFileIndexer` is an interface for feature files lookup.
-Defaults to `IoFeatureFileIndexer`, which lists files from current execution directory that match `features` patterns (similar to Glob).
+`FeatureFileMatcher` is an interface for feature files lookup.
+Defaults to `IoFeatureFileAccessor`, which lists files from current execution directory that match `features` patterns (similar to Glob).
 
 #### featureFileReader
 
 `FeatureFileReader` is an interface for feature files content read.
-Defaults to `IoFeatureFileReader`, which reads files as String with [utf-8 encoding](https://api.dart.dev/stable/2.12.2/dart-convert/utf8-constant.html).
+Defaults to `IoFeatureFileAccessor`, which reads files as String with [utf-8 encoding](https://api.dart.dev/stable/2.12.2/dart-convert/utf8-constant.html).
 
 To change encoding, use the default `IoFeatureFileReader` with custom [Encoding](https://api.dart.dev/stable/2.12.2/dart-convert/Encoding-class.html).
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -63,7 +63,9 @@ class TestConfiguration {
   FeatureFileMatcher get featureFileIndexer => featureFileMatcher;
 
   @Deprecated('Use featureFileMatcher instead')
-  set featureFileIndexer(FeatureFileMatcher matcher) => featureFileMatcher = matcher;
+  set featureFileIndexer(FeatureFileMatcher matcher) {
+    featureFileMatcher = matcher;
+  }
 
   // The feature file reader.
   // Takes files/resources paths from [featureFileIndexer] and returns their content as String.

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -57,7 +57,13 @@ class TestConfiguration {
   CreateWorld? createWorld;
 
   // Lists feature files paths, which match [features] patterns.
-  FeatureFileMatcher featureFileIndexer = const IoFeatureFileAccessor();
+  FeatureFileMatcher featureFileMatcher = const IoFeatureFileAccessor();
+
+  @Deprecated('Use featureFileMatcher instead')
+  FeatureFileMatcher get featureFileIndexer => featureFileMatcher;
+
+  @Deprecated('Use featureFileMatcher instead')
+  set featureFileIndexer(FeatureFileMatcher matcher) => featureFileMatcher = matcher;
 
   // The feature file reader.
   // Takes files/resources paths from [featureFileIndexer] and returns their content as String.

--- a/lib/src/test_runner.dart
+++ b/lib/src/test_runner.dart
@@ -93,7 +93,7 @@ class GherkinRunner {
       final featureFiles = <FeatureFile>[];
 
       for (var pattern in config.features) {
-        final paths = await config.featureFileIndexer.listFiles(pattern);
+        final paths = await config.featureFileMatcher.listFiles(pattern);
 
         for (var path in paths) {
           await _reporter.message(


### PR DESCRIPTION
Wrong interface names were used in readme for feature file accessors.