### PR TITLE
fix language line parser

### DIFF
--- a/lib/src/gherkin/syntax/language_syntax.dart
+++ b/lib/src/gherkin/syntax/language_syntax.dart
@@ -8,7 +8,7 @@ import './regex_matched_syntax.dart';
 class LanguageSyntax extends RegExMatchedGherkinSyntax {
   @override
   RegExp pattern(GherkinDialect dialect) => RegExp(
-        r'^\s*#\s*language:\s*([a-z]{2,7})\s*$',
+        r'^\s*#\s*language:\s*([a-z-]{2,7})\s*$',
         multiLine: false,
         caseSensitive: false,
       );

--- a/lib/src/gherkin/syntax/language_syntax.dart
+++ b/lib/src/gherkin/syntax/language_syntax.dart
@@ -8,7 +8,7 @@ import './regex_matched_syntax.dart';
 class LanguageSyntax extends RegExMatchedGherkinSyntax {
   @override
   RegExp pattern(GherkinDialect dialect) => RegExp(
-        r'^\s*#\s*language:\s*([a-z-]{2,7})\s*$',
+        r'^\s*#\s*language:\s*([a-z-]{2,16})\s*$',
         multiLine: false,
         caseSensitive: false,
       );

--- a/test/gherkin/syntax/language_syntax_test.dart
+++ b/test/gherkin/syntax/language_syntax_test.dart
@@ -27,6 +27,12 @@ void main() {
             EnDialectMock(),
           ),
           true);
+      expect(
+          keyword.isMatch(
+            '#language:en-au',
+            EnDialectMock(),
+          ),
+          true);
     });
 
     test('does not match', () {

--- a/test/gherkin/syntax/language_syntax_test.dart
+++ b/test/gherkin/syntax/language_syntax_test.dart
@@ -33,6 +33,12 @@ void main() {
             EnDialectMock(),
           ),
           true);
+      expect(
+          keyword.isMatch(
+            '#language:en-Scouse',
+            EnDialectMock(),
+          ),
+          true);
     });
 
     test('does not match', () {


### PR DESCRIPTION
Currently can't parse the language name with a minus that likes ```# language: en-au```, or length greater than 7 likes ```# language: en-Scouse```, it shouled be fixed.