### PR TITLE
fixes for example on non-Windows

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -5,6 +5,7 @@ To run this example:
 1. Ensure dart is accessible in the command line (on your path variable)
 2. In a command prompt (from the root of this library):
     ```bash
+    dart pub get 
     cd example
 
     dart test.dart

--- a/example/test.dart
+++ b/example/test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:gherkin/gherkin.dart';
 import 'supporting_files/hooks/hook_example.dart';
 import 'supporting_files/parameters/power_of_two.parameter.dart';
@@ -10,6 +11,14 @@ import 'supporting_files/steps/when_numbers_are_added.step.dart';
 import 'supporting_files/steps/when_the_characters_are_counted.step.dart';
 import 'supporting_files/worlds/custom_world.world.dart';
 
+String buildFeaturesPathRegex() {
+  // '\' must be escaped, '/' must not be escaped:
+  var featuresPath = (Platform.isWindows)
+      ? 'features\${Platform.pathSeparator}.*\.feature'
+      : 'features${Platform.pathSeparator}.*\.feature';
+  return featuresPath;
+}
+
 Future<void> main() {
   final steps = [
     GivenTheNumbers(),
@@ -19,7 +28,9 @@ Future<void> main() {
     WhenTheCharactersAreCounted(),
     ThenExpectNumericResult()
   ];
+  final featuresPath = buildFeaturesPathRegex();
   final config = TestConfiguration.DEFAULT(steps)
+    ..features = [RegExp(featuresPath)]
     ..tagExpression = 'not @skip'
     ..hooks = [HookExample()]
     ..customStepParameterDefinitions = [PowerOfTwoParameter()]


### PR DESCRIPTION
* `example/README.md` includes `dart pub get` for new users.
* `example/test.dart` fixes bug for finding features on non-Windows machines.
    - tested on Mac OS
    - not tested on Windows, but the code should be the same as before, which presumably worked
    - I chose to fix the example, rather than the library code, as that is my main concern. I acknowledge the argument of "let's fix the production code".  I can't commit to that, but this PR would might inform a fix.