### PR TITLE
fix: condition to incorporate `*` in regEx to match step-syntax

### DIFF
--- a/lib/src/gherkin/syntax/regex_matched_syntax.dart
+++ b/lib/src/gherkin/syntax/regex_matched_syntax.dart
@@ -12,5 +12,5 @@ abstract class RegExMatchedGherkinSyntax<TRunnable extends Runnable>
       pattern(dialect).hasMatch(line);
 
   static String getMultiDialectRegexPattern(Iterable<String> dialectVariants) =>
-      dialectVariants.map((s) => s.trim()).where((s) => s != '*').join('|');
+      dialectVariants.map((s) => s.trim().replaceAll('*', '\\*')).join('|');
 }


### PR DESCRIPTION
[The condition](https://github.com/jonsamwell/dart_gherkin/blob/2c6fa8a7564578a9e33ec295d2abde573d0cb75d/lib/src/gherkin/syntax/regex_matched_syntax.dart#L15) is making parser to ignore asterisk! And that leads parser to categorise line with `*` as text_line syntax and gives error:
`Exception: Unknown runnable child given to Scenario 'TextLineRunnable'`
