### PR TITLE
Fix typos in (and|but|given|then|when)5 functions

### DIFF
--- a/lib/src/gherkin/steps/and.dart
+++ b/lib/src/gherkin/steps/and.dart
@@ -159,10 +159,10 @@ StepDefinitionGeneric<TWorld>
   Pattern pattern,
   Future<void> Function(
     TInput1 input1,
-    TInput1 input2,
-    TInput1 input3,
-    TInput1 input4,
-    TInput1 input5,
+    TInput2 input2,
+    TInput3 input3,
+    TInput4 input4,
+    TInput5 input5,
     StepContext<TWorld> context,
   )
       onInvoke, {

--- a/lib/src/gherkin/steps/but.dart
+++ b/lib/src/gherkin/steps/but.dart
@@ -159,10 +159,10 @@ StepDefinitionGeneric<TWorld>
   Pattern pattern,
   Future<void> Function(
     TInput1 input1,
-    TInput1 input2,
-    TInput1 input3,
-    TInput1 input4,
-    TInput1 input5,
+    TInput2 input2,
+    TInput3 input3,
+    TInput4 input4,
+    TInput5 input5,
     StepContext<TWorld> context,
   )
       onInvoke, {

--- a/lib/src/gherkin/steps/given.dart
+++ b/lib/src/gherkin/steps/given.dart
@@ -160,10 +160,10 @@ StepDefinitionGeneric<TWorld>
   Pattern pattern,
   Future<void> Function(
     TInput1 input1,
-    TInput1 input2,
-    TInput1 input3,
-    TInput1 input4,
-    TInput1 input5,
+    TInput2 input2,
+    TInput3 input3,
+    TInput4 input4,
+    TInput5 input5,
     StepContext<TWorld> context,
   )
       onInvoke, {

--- a/lib/src/gherkin/steps/then.dart
+++ b/lib/src/gherkin/steps/then.dart
@@ -159,10 +159,10 @@ StepDefinitionGeneric<TWorld>
   Pattern pattern,
   Future<void> Function(
     TInput1 input1,
-    TInput1 input2,
-    TInput1 input3,
-    TInput1 input4,
-    TInput1 input5,
+    TInput2 input2,
+    TInput3 input3,
+    TInput4 input4,
+    TInput5 input5,
     StepContext<TWorld> context,
   )
       onInvoke, {

--- a/lib/src/gherkin/steps/when.dart
+++ b/lib/src/gherkin/steps/when.dart
@@ -160,10 +160,10 @@ StepDefinitionGeneric<TWorld>
   Pattern pattern,
   Future<void> Function(
     TInput1 input1,
-    TInput1 input2,
-    TInput1 input3,
-    TInput1 input4,
-    TInput1 input5,
+    TInput2 input2,
+    TInput3 input3,
+    TInput4 input4,
+    TInput5 input5,
     StepContext<TWorld> context,
   )
       onInvoke, {


### PR DESCRIPTION
Fixed some small typos on the arguments of the function provided to `and5`, `but5`, `given5`, `then5`, and `when5`.