### PR TITLE
Fix pattern matching for feature files

### DIFF
--- a/example/test.dart
+++ b/example/test.dart
@@ -21,7 +21,7 @@ Future<void> main() {
   ];
 
   final config = TestConfiguration(
-    features: [RegExp(r'features\\.+\.feature')],
+    features: [RegExp(r'features\/[a-z_]{0,}\.feature')],
     reporters: [
       StdoutReporter(MessageLevel.error),
       ProgressReporter(),


### PR DESCRIPTION
Fixed an incorrect comparison by the pattern of file names for a feature. This issue is related to this #65 